### PR TITLE
增加只转译 atrace 的命令

### DIFF
--- a/scripts/python/rheatrace/common/context.py
+++ b/scripts/python/rheatrace/common/context.py
@@ -47,6 +47,7 @@ class Context:
         self.advanced_systrace_time = options.advanced_systrace_time
         self.list_categories = options.list_categories
         self.debug = options.debug
+        self.only_decode_atrace = options.only_decode_atrace
 
     def set_params(self, key, value):
         if self.environment_params is not None:

--- a/scripts/python/rheatrace/rhea_config.py
+++ b/scripts/python/rheatrace/rhea_config.py
@@ -20,7 +20,7 @@ VERSION_CODE = "1.1.0"
 
 ORIGIN_SYSTRACE_FILE = "systrace-origin.html"
 ORIGIN_SYSTRACE_FS_FILE = 'systrace-fs-origin.html'
-ATRACE_APP_GZ_FILE_LOCATION = "sdcard/rhea-trace/%s/"
+ATRACE_APP_GZ_FILE_LOCATION = "/sdcard/Android/data/rhea.sample.android/cache/rhea-trace/%s/"
 ATRACE_GZ_FILE = 'rhea-atrace.gz'
 ATRACE_BINDER_FILE = 'binder.txt'
 ATRACE_RAW_FILE = 'rhea-atrace'


### PR DESCRIPTION
增加只转译 atrace 的命令。 
python rheatrace.py --only-decode-atrace -a rhea.sample.android
最后会生成可使用 perfetto 解析的 atrace-standard 文件。

之前的 rheatrace 脚本只支持带有 systrace 的基础上才能进行转换。