### PR TITLE
When the script copy is complete, release the IO

### DIFF
--- a/rhea-tool/rhea-trace-processor/src/main/java/com/bytedance/rheatrace/processor/perfetto/PerfettoCapture.java
+++ b/rhea-tool/rhea-trace-processor/src/main/java/com/bytedance/rheatrace/processor/perfetto/PerfettoCapture.java
@@ -21,6 +21,7 @@ import com.bytedance.rheatrace.processor.core.TraceError;
 import com.bytedance.rheatrace.processor.core.Workspace;
 import com.bytedance.rheatrace.processor.os.OS;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -28,7 +29,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.util.List;
 
 /**
@@ -44,7 +44,7 @@ public class PerfettoCapture implements SystemLevelCapture {
         File bin = Workspace.perfettoBinary();
         try (InputStream perfetto = TraceProcessor.class.getResourceAsStream("/" + OS.get().perfettoScriptName())) {
             assert perfetto != null;
-            IOUtils.copy(perfetto, Files.newOutputStream(bin.toPath()));
+            FileUtils.copyInputStreamToFile(perfetto, bin);
             OS.get().setExecutable(bin);
         }
         Log.d("record_android_trace ready: " + bin.getAbsolutePath());


### PR DESCRIPTION
Executing rhea-trace-processor on Ubuntu throws error=26 if IO is not turned off

```shell

$ java -jar rhea-trace-processor-2.0.3-rc02.jar -a rhea.sample.android  -t 10 -r rhea.all sched -fullClassName
07-24 15:43:52.119 I RheaTrace : no `-o output` specified. using the generated path:2023_07_24_15_43_52_119.pb
07-24 15:43:52.127 I RheaTrace : workspace clear: /home/prosixe/Downloads/btrace/rhea-tool/rhea-trace-processor/build/libs/rheatrace.workspace
07-24 15:43:52.483 I RheaTrace : os version is 33. default capture is PerfettoCapture
Exception in thread "Thread-1" com.bytedance.rheatrace.processor.core.TraceError: Cannot run program "/home/prosixe/Downloads/btrace/rhea-tool/rhea-trace-processor/build/libs/rheatrace.workspace/record_android_trace": error=26, 文本文件忙
        at com.bytedance.rheatrace.processor.Main.lambda$main$1(Main.java:81)
        at java.lang.Thread.run(Thread.java:750)
Caused by: java.io.IOException: Cannot run program "/home/prosixe/Downloads/btrace/rhea-tool/rhea-trace-processor/build/libs/rheatrace.workspace/record_android_trace": error=26, 文本文件忙
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
        at java.lang.Runtime.exec(Runtime.java:593)
        at java.lang.Runtime.exec(Runtime.java:458)
        at com.bytedance.rheatrace.processor.perfetto.PerfettoCapture.start(PerfettoCapture.java:55)
        at com.bytedance.rheatrace.processor.Main.lambda$main$1(Main.java:73)
        ... 1 more
Caused by: java.io.IOException: error=26, 文本文件忙
        at java.lang.UNIXProcess.forkAndExec(Native Method)
        at java.lang.UNIXProcess.<init>(UNIXProcess.java:247)
        at java.lang.ProcessImpl.start(ProcessImpl.java:134)
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
        ... 5 more
07-24 15:43:54.484   RheaTrace : start tracing...
07-24 15:44:04.623   RheaTrace : stop tracing...
07-24 15:44:04.716   RheaTrace : MaxAppTraceBufferSize usage 592432/500000000 (0%)
07-24 15:44:04.848 E RheaTrace : Error: systrace file not found: rheatrace.workspace/systemTrace.trace
07-24 15:44:04.848 E RheaTrace :  Tips: your device may not support perfetto. please retry with `-mode simple`.

```