### PR TITLE
Fix Android trace robustness and port discovery

### DIFF
--- a/btrace-android/rhea-library/rhea-inhouse/src/main/cpp/base/PerfCollectorBaseImpl.h
+++ b/btrace-android/rhea-library/rhea-inhouse/src/main/cpp/base/PerfCollectorBaseImpl.h
@@ -33,22 +33,34 @@ public:
         int dirPathLen = strlen(outDir);
         char* path = new char[dirPathLen + 64]; // suppose that dumpFileName is not longer than 64
         sprintf(path, "%s/%s", outDir, getDumpPerfFileName());
-        int fd = open(path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP);
+        int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP);
         if (fd == -1) {
-            return errno;
+            int error = errno;
+            delete[] path;
+            return error;
         }
         Dumper* dumper = newDumper();
         int mappingFd = -1;
         if (dumper != nullptr && dumper->hasMapping()) {
             memset(path, 0, dirPathLen + 64);
             sprintf(path, "%s/%s", outDir, getDumpMappingFileName());
-            mappingFd = open(path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP);
+            mappingFd = open(path, O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP);
+            if (mappingFd == -1) {
+                int error = errno;
+                delete[] path;
+                delete dumper;
+                close(fd);
+                return error;
+            }
         }
         uint64_t curTime = current_boot_time_millis();
         int result = mBuffer->dump(env, fd, mappingFd, type, version, curTime, extra, extraLen,
                                    dumpRawData, dumper);
         delete[] path;
         delete dumper;
+        if (mappingFd != -1) {
+            close(mappingFd);
+        }
         close(fd);
         return result;
     }
@@ -61,22 +73,34 @@ public:
         int dirPathLen = strlen(outDir);
         char* path = new char[dirPathLen + 64]; // suppose that dumpFileName is not longer than 64
         sprintf(path, "%s/%s", outDir, getDumpPerfFileName());
-        int fd = open(path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP);
+        int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP);
         if (fd == -1) {
-            return errno;
+            int error = errno;
+            delete[] path;
+            return error;
         }
         Dumper* dumper = newDumper();
         int mappingFd = -1;
         if (dumper != nullptr && dumper->hasMapping()) {
             memset(path, 0, dirPathLen + 64);
             sprintf(path, "%s/%s", outDir, getDumpMappingFileName());
-            mappingFd = open(path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP);
+            mappingFd = open(path, O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP);
+            if (mappingFd == -1) {
+                int error = errno;
+                delete[] path;
+                delete dumper;
+                close(fd);
+                return error;
+            }
         }
         uint64_t curTime = current_boot_time_millis();
         int result = mBuffer->dumpPart(env, fd, mappingFd, type, version, curTime, extra, extraLen,
                                        dumpRawData, dumper, startTicket, endTicket);
         delete[] path;
         delete dumper;
+        if (mappingFd != -1) {
+            close(mappingFd);
+        }
         close(fd);
         return result;
     }

--- a/btrace-android/rhea-library/rhea-inhouse/src/main/cpp/sampling/SamplingCollector.cpp
+++ b/btrace-android/rhea-library/rhea-inhouse/src/main/cpp/sampling/SamplingCollector.cpp
@@ -24,6 +24,7 @@
 #include <setjmp.h>
 #include <sys/resource.h>
 #include <dirent.h>
+#include <cstring>
 #include <string>
 
 #include "../utils/time.h"
@@ -80,7 +81,7 @@ bool SamplingCollector::request(SamplingType type, void* self, bool force, bool 
             return false;
         }
         r.mType = type;
-        r.mTid = gettid();
+        r.mTid = static_cast<uint32_t>(gettid());
         r.mMessageId = messageIndex;
 
         auto& objectStat = JavaObjectStat::getAllocatedObjectStat();
@@ -177,7 +178,7 @@ bool SamplingDumper::dumpMapping(int fd) {
     }
     if (sigsetjmp(dumpMappingJmp, 1) == 0) {
         uint64_t magic = 0;
-        uint32_t version = 1;
+        uint32_t version = 2;
         write(fd, &magic, sizeof(magic));
         write(fd, &version, sizeof(version));
         uint32_t count = mMethodIds.size();
@@ -207,9 +208,11 @@ bool SamplingDumper::dumpMapping(int fd) {
                         if (file) {
                             char thread_name[17];
                             if (fgets(thread_name, sizeof(thread_name), file) != nullptr) {
-                                write(fd, &tid, 2);
                                 thread_name[16] = 0;
-                                uint8_t len = strlen(thread_name);
+                                thread_name[strcspn(thread_name, "\r\n")] = 0;
+                                uint32_t tid32 = static_cast<uint32_t>(tid);
+                                write(fd, &tid32, sizeof(tid32));
+                                uint8_t len = static_cast<uint8_t>(strlen(thread_name));
                                 write(fd, &len, 1);
                                 write(fd, thread_name, len);
                             }
@@ -217,8 +220,8 @@ bool SamplingDumper::dumpMapping(int fd) {
                         }
                     }
                 }
+                closedir(dir);
             }
-            closedir(dir);
             auto cost = current_boot_time_millis() - now;
             ALOGD("dump thread names cost %lums", cost);
         }

--- a/btrace-android/rhea-library/rhea-inhouse/src/main/cpp/sampling/SamplingCollector.h
+++ b/btrace-android/rhea-library/rhea-inhouse/src/main/cpp/sampling/SamplingCollector.h
@@ -30,7 +30,7 @@ namespace rheatrace {
  * preset trace point to capture java stack synchronously and saved it to buffer inside this
  * collector.
  */
-class SamplingCollector : public PerfCollectorBaseImpl<rheatrace::TYPE_SAMPLING, 5, false, SamplingRecord> {
+class SamplingCollector : public PerfCollectorBaseImpl<rheatrace::TYPE_SAMPLING, 6, false, SamplingRecord> {
 public:
     static SamplingCollector* create(JNIEnv* env, jlongArray configs);
 
@@ -78,7 +78,7 @@ protected:
 private:
 
     SamplingCollector(PerfBuffer<SamplingRecord>* buffer, SamplingConfig& config)
-            : PerfCollectorBaseImpl<rheatrace::TYPE_SAMPLING, 5, false, SamplingRecord>(buffer),
+            : PerfCollectorBaseImpl<rheatrace::TYPE_SAMPLING, 6, false, SamplingRecord>(buffer),
               config(config), paused(false) {
     }
 

--- a/btrace-android/rhea-library/rhea-inhouse/src/main/cpp/sampling/SamplingRecord.h
+++ b/btrace-android/rhea-library/rhea-inhouse/src/main/cpp/sampling/SamplingRecord.h
@@ -50,7 +50,7 @@ enum class SamplingType {
 
 struct SamplingRecord {
     SamplingType mType;
-    uint16_t mTid;
+    uint32_t mTid;
     uint32_t mMessageId;
     uint64_t mNanoTime; // when mType is kUnpark/kNotify/kUnlock, this property represents the time of corresponding park/wait/lock
     uint64_t mCpuTime;
@@ -64,17 +64,17 @@ struct SamplingRecord {
     Stack mStack;
 
     uint32_t size() {
-        return 2 + 2 + 4 + 8 * 6 + 4 * 3 + mStack.size();
+        return 2 + 4 + 4 + 8 * 6 + 4 * 3 + mStack.size();
     }
 
     static uint32_t maxBytes() {
-        return 2 + 2 + 4 + 8 * 6 + 4 * 3 + Stack::maxSize();
+        return 2 + 4 + 4 + 8 * 6 + 4 * 3 + Stack::maxSize();
     }
 
     uint32_t encodeInto(char* out, std::unordered_set<uint64_t>* set) {
         int size = 0;
         size += rheatrace::writeBuf(out + size, (uint16_t) mType);
-        size += rheatrace::writeBuf(out + size, (uint16_t) mTid);
+        size += rheatrace::writeBuf(out + size, mTid);
         size += rheatrace::writeBuf(out + size, mMessageId);
         size += rheatrace::writeBuf(out + size, mNanoTime);
         size += rheatrace::writeBuf(out + size, mEndNanoTime);

--- a/btrace-android/rhea-library/rhea-inhouse/src/main/java/com/bytedance/rheatrace/TraceManager.java
+++ b/btrace-android/rhea-library/rhea-inhouse/src/main/java/com/bytedance/rheatrace/TraceManager.java
@@ -40,8 +40,10 @@ public class TraceManager {
 
     private static final String TAG = "RheaTrace:Manager";
 
+    private final Object traceLock = new Object();
     private String tracingDirPath;
     private long[] traceTokens = null;
+    private boolean startInProgress = false;
 
     public static TraceManager getInstance() {
         return Holder.INSTANCE;
@@ -52,15 +54,11 @@ public class TraceManager {
             startTracing(false);
         }
         tracingDirPath = context.getFilesDir().getAbsolutePath() + "/rhea/tracing/" + Process.myPid();
-        Thread serverThread = new Thread(() -> HttpServer.start(context.getExternalFilesDir(null), tracingDirPath));
+        Thread serverThread = new Thread(() -> HttpServer.start(context.getExternalFilesDirs(null), tracingDirPath));
         serverThread.start();
     }
 
     public boolean startTracing(boolean async) {
-        if (traceTokens != null) {
-            Log.e(TAG, "start failed: already started and not yet stopped");
-            return false;
-        }
         if (!TraceGlobal.init()) {
             Log.e(TAG, "start failed: global dependency init failed");
             return false;
@@ -69,30 +67,60 @@ public class TraceManager {
         if (traceMetas.isEmpty()) {
             return false;
         }
-        if (async) {
-            Thread startThread = new Thread(() -> {
-                List<TraceAbility<?>> traceAbilities = TraceAbilityCenter.getAbilities(traceMetas);
-                long[] tokens = new long[traceMetas.size()];
-                for (int i = 0; i < traceMetas.size(); i++) {
-                    tokens[i] = traceAbilities.get(i).start();
-                }
-                this.traceTokens = tokens;
-            });
-            startThread.start();
-        } else {
-            List<TraceAbility<?>> traceAbilities = TraceAbilityCenter.getAbilities(traceMetas);
-            long[] tokens = new long[traceMetas.size()];
-            for (int i = 0; i < traceMetas.size(); i++) {
-                tokens[i] = traceAbilities.get(i).start();
+        synchronized (traceLock) {
+            if (traceTokens != null || startInProgress) {
+                Log.e(TAG, "start failed: already started and not yet stopped");
+                return false;
             }
-            this.traceTokens = tokens;
+            if (async) {
+                startInProgress = true;
+                Thread startThread = new Thread(() -> {
+                    try {
+                        long[] tokens = startTrace(traceMetas);
+                        synchronized (traceLock) {
+                            this.traceTokens = tokens;
+                        }
+                    } catch (Throwable t) {
+                        Log.e(TAG, "async start failed", t);
+                    } finally {
+                        synchronized (traceLock) {
+                            startInProgress = false;
+                            traceLock.notifyAll();
+                        }
+                    }
+                });
+                startThread.start();
+            } else {
+                this.traceTokens = startTrace(traceMetas);
+            }
+            return true;
         }
-        return true;
+    }
+
+    private long[] startTrace(List<TraceMeta> traceMetas) {
+        List<TraceAbility<?>> traceAbilities = TraceAbilityCenter.getAbilities(traceMetas);
+        long[] tokens = new long[traceMetas.size()];
+        for (int i = 0; i < traceMetas.size(); i++) {
+            tokens[i] = traceAbilities.get(i).start();
+        }
+        return tokens;
     }
 
     public boolean stopTracing() {
-        long[] startTokens = this.traceTokens;
-        traceTokens = null;
+        long[] startTokens;
+        synchronized (traceLock) {
+            while (startInProgress) {
+                try {
+                    traceLock.wait(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    Log.e(TAG, "stop interrupted while waiting start to finish", e);
+                    return false;
+                }
+            }
+            startTokens = this.traceTokens;
+            traceTokens = null;
+        }
         if (startTokens == null) {
             Log.e(TAG, "stop failed: no start tokens");
             return false;
@@ -108,9 +136,13 @@ public class TraceManager {
             JSONObject extra = getExtra();
             String extraStr = extra == null ? "" : extra.toString();
             String path = getDumpPath();
+            int dumpResult = 0;
             if (!makeDumpDir(path)) {
                 Log.e(TAG, "make dump dir failed: " + path);
-                HttpServer.getServer().onTraceDumpFinished(-100, getDumpPath(), traceMetas, startTokens, endTokens);
+                HttpServer.Server server = HttpServer.getServer();
+                if (server != null) {
+                    server.onTraceDumpFinished(-100, getDumpPath(), traceMetas, startTokens, endTokens);
+                }
                 return;
             }
             for (int i = 0; i < traceMetas.size(); i++) {
@@ -120,9 +152,15 @@ public class TraceManager {
                 int result = ability.dumpTokenRange(startToken, endToken, path, extraStr);
                 if (result != 0) {
                     Log.e(TAG, "dumping failed for " + traceMetas.get(i).getName() + ", error code is " + result);
+                    if (dumpResult == 0) {
+                        dumpResult = result;
+                    }
                 }
             }
-            HttpServer.getServer().onTraceDumpFinished(0, getDumpPath(), traceMetas, startTokens, endTokens);
+            HttpServer.Server server = HttpServer.getServer();
+            if (server != null) {
+                server.onTraceDumpFinished(dumpResult, getDumpPath(), traceMetas, startTokens, endTokens);
+            }
         });
         return true;
     }

--- a/btrace-android/rhea-library/rhea-inhouse/src/main/java/com/bytedance/rheatrace/server/HttpServer.java
+++ b/btrace-android/rhea-library/rhea-inhouse/src/main/java/com/bytedance/rheatrace/server/HttpServer.java
@@ -40,7 +40,7 @@ public final class HttpServer {
         return server;
     }
 
-    public static void start(File externalFileDir, String hostDirPath) {
+    public static void start(File[] externalFileDirs, String hostDirPath) {
         if (server != null && server.isAlive()) {
             Log.i(TAG, "stop previous server on port " + server.getListeningPort());
             server.stop();
@@ -49,24 +49,60 @@ public final class HttpServer {
         try {
             server.start();
             int port = server.getListeningPort();
-            makePortDir(externalFileDir, port);
+            publishPort(externalFileDirs, port);
             Log.i(TAG, "start new http server on port " + port);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            Log.e(TAG, "start http server failed", e);
+            server = null;
+        }
+    }
+
+    private static void publishPort(File[] externalFileDirs, int port) {
+        if (externalFileDirs == null) {
+            return;
+        }
+        for (File externalFileDir : externalFileDirs) {
+            if (externalFileDir != null) {
+                makePortDir(externalFileDir, port);
+            }
         }
     }
 
     private static void makePortDir(File externalFileDir, int port) {
         File portDir = new File(externalFileDir, "rhea-port");
-        if (!portDir.exists()) {
-            portDir.mkdirs();
+        if (!portDir.exists() && !portDir.mkdirs()) {
+            Log.w(TAG, "make port dir failed: " + portDir.getAbsolutePath());
+            return;
         }
         File[] ports = portDir.listFiles();
-        if (ports == null || ports.length == 0) {
-            File realPortDir = new File(portDir, String.valueOf(port));
-            realPortDir.mkdirs();
-        } else {
-            ports[0].renameTo(new File(portDir, String.valueOf(port)));
+        if (ports != null) {
+            for (File oldPort : ports) {
+                if (oldPort == null) {
+                    continue;
+                }
+                if (String.valueOf(port).equals(oldPort.getName())) {
+                    return;
+                }
+                deleteRecursively(oldPort);
+            }
+        }
+        File realPortDir = new File(portDir, String.valueOf(port));
+        if (!realPortDir.exists() && !realPortDir.mkdirs()) {
+            Log.w(TAG, "make real port dir failed: " + realPortDir.getAbsolutePath());
+        }
+    }
+
+    private static void deleteRecursively(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursively(child);
+                }
+            }
+        }
+        if (!file.delete()) {
+            Log.w(TAG, "delete stale port path failed: " + file.getAbsolutePath());
         }
     }
 
@@ -98,14 +134,22 @@ public final class HttpServer {
                     case "start":
                         // Start trace asynchronously so that hooked Thread::init() will be called on newly created thread
                         // and we can get thread_list instance to monitor java object allocation.
-                        TraceManager.getInstance().startTracing(true);
+                        if (!TraceManager.getInstance().startTracing(true)) {
+                            error = "start trace failed";
+                            dataFlushFinished = true;
+                            return newFixedLengthResponse(Response.Status.INTERNAL_ERROR, MIME_PLAINTEXT, error);
+                        }
                         dataFlushFinished = false;
                         error = null;
                         traceDebugInfo = null;
                         Log.i(TAG, "rhea trace started");
                         return newFixedLengthResponse(Response.Status.OK, MIME_PLAINTEXT, "start trace");
                     case "stop":
-                        TraceManager.getInstance().stopTracing();
+                        if (!TraceManager.getInstance().stopTracing()) {
+                            error = "stop trace failed";
+                            dataFlushFinished = true;
+                            return newFixedLengthResponse(Response.Status.INTERNAL_ERROR, MIME_PLAINTEXT, error);
+                        }
                         Log.i(TAG, "rhea trace stopped");
                         return newFixedLengthResponse(Response.Status.OK, MIME_PLAINTEXT, "stop trace");
                     case "clean":
@@ -194,7 +238,8 @@ public final class HttpServer {
                 try {
                     Thread.sleep(1000);
                 } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+                    Thread.currentThread().interrupt();
+                    return false;
                 }
             }
             return false;

--- a/btrace-android/rhea-library/rhea-inhouse/src/main/java/com/bytedance/rheatrace/trace/base/TraceGlobal.java
+++ b/btrace-android/rhea-library/rhea-inhouse/src/main/java/com/bytedance/rheatrace/trace/base/TraceGlobal.java
@@ -32,7 +32,7 @@ public class TraceGlobal {
             nativeInit(Looper.getMainLooper().getThread());
             JNIHook.init();
             success = true;
-        } catch (Exception e) {
+        } catch (Throwable e) {
             Log.e(TAG, "rhea-trace init failed: ", e);
             success = false;
         }

--- a/btrace-android/rhea-tool/rhea-trace-processor/src/main/java/com/bytedance/rheatrace/Main.java
+++ b/btrace-android/rhea-tool/rhea-trace-processor/src/main/java/com/bytedance/rheatrace/Main.java
@@ -32,6 +32,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Scanner;
 import java.util.StringTokenizer;
@@ -141,11 +142,23 @@ public class Main {
     }
 
     private static void prepareAdbForward(Arguments arg) throws IOException, InterruptedException {
-        int appServerPort;
-        try {
-            appServerPort = getAppServerPort(arg);
-        } catch (Exception e) {
-            throw new TraceError("prepare adb forward failed", "get app server port failed", e);
+        int appServerPort = -1;
+        Exception lastError = null;
+        for (int i = 0; i < 10 && appServerPort <= 0; i++) {
+            try {
+                appServerPort = getAppServerPort(arg);
+            } catch (Exception e) {
+                lastError = e;
+            }
+            if (appServerPort > 0) {
+                break;
+            }
+            if (i < 9) {
+                Thread.sleep(500);
+            }
+        }
+        if (appServerPort <= 0 && lastError != null) {
+            throw new TraceError("prepare adb forward failed", "get app server port failed", lastError);
         }
         if (appServerPort <= 0) {
             throw new TraceError("cannot establish connection to app trace server", "server port not found");
@@ -154,20 +167,52 @@ public class Main {
     }
 
     private static int getAppServerPort(Arguments arg) throws IOException, InterruptedException {
-        String dirPath = "/storage/emulated/0/Android/data/" + arg.appName + "/files/rhea-port";
-        String results = Adb.callString("shell", "ls", dirPath);
-        String[] lines = results.split("\n");
-        for (String line : lines) {
-            try {
-                int possiblePort = Integer.parseInt(line);
-                if (possiblePort > 0) {
-                    return possiblePort;
-                }
-            } catch (Exception e) {
-                Log.red(e.getMessage());
+        for (String dirPath : getAppServerPortDirCandidates(arg.appName)) {
+            Integer port = tryReadPortFromDir(dirPath);
+            if (port != null && port > 0) {
+                return port;
             }
         }
         return -1;
+    }
+
+    private static List<String> getAppServerPortDirCandidates(String appName) throws IOException, InterruptedException {
+        LinkedHashSet<String> candidates = new LinkedHashSet<>();
+        candidates.add("/storage/emulated/0/Android/data/" + appName + "/files/rhea-port");
+        candidates.add("/sdcard/Android/data/" + appName + "/files/rhea-port");
+        StringBuilder script = new StringBuilder();
+        script.append("for d in ");
+        script.append("/storage/emulated/*/Android/data/").append(appName).append("/files/rhea-port ");
+        script.append("/mnt/shell/emulated/*/Android/data/").append(appName).append("/files/rhea-port");
+        script.append("; do if [ -d \"$d\" ]; then echo \"$d\"; fi; done");
+        String results = Adb.callString("shell", "sh", "-c", script.toString());
+        for (String line : results.split("\n")) {
+            String candidate = line.trim();
+            if (!candidate.isEmpty()) {
+                candidates.add(candidate);
+            }
+        }
+        return new ArrayList<>(candidates);
+    }
+
+    private static Integer tryReadPortFromDir(String dirPath) {
+        try {
+            String results = Adb.callString("shell", "ls", dirPath);
+            String[] lines = results.split("\n");
+            for (String line : lines) {
+                try {
+                    int possiblePort = Integer.parseInt(line.trim());
+                    if (possiblePort > 0) {
+                        return possiblePort;
+                    }
+                } catch (Exception e) {
+                    Log.d("skip invalid port entry `" + line + "` in " + dirPath);
+                }
+            }
+        } catch (Exception e) {
+            Log.d("read app server port dir failed: " + dirPath + ", " + e.getMessage());
+        }
+        return null;
     }
 
     private static void removeForwardPort() {

--- a/btrace-android/rhea-tool/rhea-trace-processor/src/main/java/com/bytedance/rheatrace/core/Arguments.java
+++ b/btrace-android/rhea-tool/rhea-trace-processor/src/main/java/com/bytedance/rheatrace/core/Arguments.java
@@ -203,9 +203,11 @@ public class Arguments {
                         };
                         break;
                     case "-waitTraceTimeout":
+                        ensureKeyWithValue(args, i);
                         waitTraceTimeout = Integer.parseInt(args[i++]);
                         break;
                     case "-launcher":
+                        ensureKeyWithValue(args, i);
                         launcher = args[i++];
                         break;
                     default:

--- a/btrace-android/rhea-tool/rhea-trace-processor/src/main/java/com/bytedance/rheatrace/trace/SamplingMappingDecoder.java
+++ b/btrace-android/rhea-tool/rhea-trace-processor/src/main/java/com/bytedance/rheatrace/trace/SamplingMappingDecoder.java
@@ -40,9 +40,9 @@ public class SamplingMappingDecoder {
         int version = buffer.getInt();
         int count = buffer.getInt();
         for (int i = 0; i < count; i++) {
-            if (buffer.remaining() > 12) {
+            if (buffer.remaining() >= 10) {
                 long pointer = buffer.getLong();
-                short len = buffer.getShort();
+                int len = buffer.getShort() & 0xffff;
                 if (len > 0) {
                     byte[] b = new byte[len];
                     buffer.get(b);
@@ -53,7 +53,7 @@ public class SamplingMappingDecoder {
             }
         }
         while (buffer.hasRemaining()) {
-            int tid = buffer.getShort();
+            int tid = version >= 2 ? buffer.getInt() : (buffer.getShort() & 0xffff);
             int len = buffer.get();
             if (len > 0 && len <= buffer.remaining()) {
                 byte[] name = new byte[len];

--- a/btrace-android/rhea-tool/rhea-trace-processor/src/main/java/com/bytedance/rheatrace/trace/StackList.java
+++ b/btrace-android/rhea-tool/rhea-trace-processor/src/main/java/com/bytedance/rheatrace/trace/StackList.java
@@ -165,7 +165,7 @@ public class StackList {
         Map<Long, Integer> wakers = new HashMap<>();
         while (buffer.hasRemaining()) {
             int type = buffer.getShort() & 0xffff;
-            int tid = buffer.getShort();
+            int tid = version >= 6 ? buffer.getInt() : (buffer.getShort() & 0xffff);
             int messageId = buffer.getInt();
             long nanoTime = buffer.getLong();
             long nanoTimeEnd = buffer.getLong();


### PR DESCRIPTION
## Summary
- catch Android trace init failures at the  level so library/JNI load issues do not crash app startup
- harden app trace server startup and host-side port discovery across external storage paths and startup timing
- propagate dump failures correctly, close dump file descriptors, and truncate stale outputs
- encode sampling/thread-name tids as 32-bit and keep decoder compatibility with older mapping data
- add missing CLI argument validation for  and 

## Verification
- 
- 